### PR TITLE
Update cmoc and pin python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER Jamie Cho version: 0.15
+MAINTAINER Jamie Cho version: 0.16
 
 # Setup sources
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
@@ -28,28 +28,20 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 # Install useful Python tools
 RUN pip install \
-  numpy \
-  Pillow \
-  pypng \
-  wand
+  numpy==1.16.5 \
+  Pillow==6.2.0 \
+  pypng==0.0.20 \
+  wand==0.5.7
 
 # Install CoCo Specific stuff
 RUN add-apt-repository ppa:tormodvolden/m6809 && \
   echo deb http://ppa.launchpad.net/tormodvolden/m6809/ubuntu trusty main >> /etc/apt/sources.list.d/tormodvolden-m6809-trusty.list && \
   echo deb http://ppa.launchpad.net/tormodvolden/m6809/ubuntu precise main >> /etc/apt/sources.list.d/tormodvolden-m6809-trusty.list && \
   apt-get update && apt-get upgrade -y && apt-get install -y \
+  cmoc=0.1.60-0~tormod \
   gcc6809=4.6.4-0~lw9a~trusty \
   lwtools=4.17-0~tormod~~trusty \
   toolshed=2.2-0~tormod
-
-# Install cmoc
-WORKDIR /root
-RUN curl http://perso.b2b2c.ca/~sarrazip/dev/cmoc-0.1.59.tar.gz -o cmoc.tar.gz && \
-  tar -zxpvf cmoc.tar.gz && \
-  (cd cmoc-0.1.59 && \
-  ./configure && \
-  make && \
-  make install)
 
 # Install CoCo image conversion scripts
 RUN git config --global core.autocrlf input && \
@@ -81,10 +73,10 @@ RUN git clone https://github.com/tlindner/cmoc_os9.git && \
 RUN git clone https://github.com/mikeakohn/naken_asm.git && \
   git clone https://github.com/mikeakohn/java_grinder && \
   (cd naken_asm && \
-  git checkout d6f2440a712c5b0df1394c669dbb8ed13eb715a0 && \
+  git checkout e9ad7c8181c39ed09bde0d9fd1c285a2ee97edd7 && \
   ./configure && make && make install && \
   cd ../java_grinder && \
-  git checkout d24d79e6f9820e3ece3aa7aa38b1bedfb031f5e7 && \
+  git checkout b3ef7b33343fd877573af5f63502393ffe31f9ab && \
   make && make java && \
   (cd samples/trs80_coco && make grind) && \
   cp java_grinder /usr/local/bin/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Color Computer](https://en.wikipedia.org/wiki/TRS-80_Color_Computer)
 applications. It implements a Docker image that includes the following tools:
 * [LWTOOLS 4.17](http://lwtools.projects.l-w.ca)
 * [ToolShed 2.2](https://sourceforge.net/p/toolshed/wiki/Home/)
-* [CMOC 0.1.59](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
+* [CMOC 0.1.60](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
 * [gcc6809](https://launchpad.net/~tormodvolden/+archive/ubuntu/m6809)
 * [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
 * [milliluk-tools](https://github.com/milliluk/milliluk-tools)

--- a/build
+++ b/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 docker-compose -f docker-compose.build.yml build
-docker tag coco-dev_coco-dev:latest jamieleecho/coco-dev:0.15
+docker tag coco-dev_coco-dev:latest jamieleecho/coco-dev:0.16
 

--- a/coco-dev
+++ b/coco-dev
@@ -7,7 +7,7 @@ else
   params=( bash )
 fi
 
-COCO_DEV_IMAGE=jamieleecho/coco-dev:0.15
+COCO_DEV_IMAGE=jamieleecho/coco-dev:0.16
 
 case "$(uname -s)" in
 


### PR DESCRIPTION
Updates
* `cmoc` to 0.1.60
* `jgrinder` and `naken_asm` to latest versions in github
* Pins python libraries