### PR TITLE
Add KAOS, remove gcc-6809, upgrade Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 MAINTAINER Jamie Cho version: 0.47
 
@@ -7,19 +7,23 @@ WORKDIR /root
 
 # Setup sources
 RUN export DEBIAN_FRONTEND=noninteractive && \
-  apt-get update && \
-  apt-get install -y software-properties-common && \
-  add-apt-repository ppa:deadsnakes/ppa && \
-  add-apt-repository ppa:ubuntu-toolchain-r/test && \
-  add-apt-repository ppa:tormodvolden/m6809 && \
+  apt-get update -y && \
+  apt-get install -y curl && \
+  curl https://packages.microsoft.com/config/ubuntu/22.10/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+  dpkg -i packages-microsoft-prod.deb && \
+  rm packages-microsoft-prod.deb && \
+  curl http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1\~18.04.20_amd64.deb -o 18.04.20_amd64.deb && \
+  dpkg -i 18.04.20_amd64.deb && \
+  rm 18.04.20_amd64.deb && \
   apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y \
+    aspnetcore-runtime-3.1 \
     bison \
     build-essential \
-    curl \
     default-jdk \
     dos2unix \
+    dotnet-sdk-7.0 \
     ffmpeg \
     flex \
     fuse \
@@ -31,18 +35,18 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libmagickwand-dev \
     mame-tools \
     markdown \
-    python3.10 \
-    python3.10-dev \
-    python3.10-distutils \
-    python3.10-tk \
+    p7zip \
+    python3 \
+    python3-dev \
+    python3-distutils \
+    python3-tk \
     software-properties-common \
     vim \
-    zlib1g-dev && \
-  apt-get purge -y python3.6
+    zlib1g-dev
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.10 2 && \
-  curl https://bootstrap.pypa.io/get-pip.py | python3 && \
+  curl https://bootstrap.pypa.io/get-pip.py | python && \
   pip install \
     mercurial==6.2.2 \
     numpy==1.22.2 \
@@ -53,10 +57,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
     coco-tools==0.6 \
     milliluk-tools==0.1 \
     mc10-tools==0.5
-
-# Install CoCo Specific stuff
-RUN apt-get install -y \
-  gcc6809=4.6.4-0~lw9a1~bionic3
 
 # Install lwtools
 RUN hg clone http://www.lwtools.ca/hg && \
@@ -138,6 +138,18 @@ RUN git clone https://github.com/emmanuel-marty/salvador && \
   (PATH=./clang-hack:$PATH make) && \
   rm -r ./clang-hack && \
   cp salvador /usr/local/bin)
+
+# Install KAOS.Assembler
+RUN git clone https://github.com/ChetSimpson/KAOS.Assembler.git && \
+  (cd KAOS.Assembler && \
+  git checkout 4f61e3f859b76990dd78b56a99fe472e56b5684a && \
+  gcc src/*.c -o /usr/local/bin/kasm)
+
+# Install KAOS
+RUN curl -L https://github.com/ChetSimpson/KAOSToolkit-Prototype/releases/download/1.0.0/KAOSTKPT.7z -o KAOSTKPT.7z && \
+  7zr x KAOSTKPT.7z && \
+  cp KAOSTKPT/*.dll KAOSTKPT/*.json /usr/local/bin
+COPY kaos/* /usr/local/bin/
 
 # Clean up
 RUN ln -s /home /Users && \

--- a/README.md
+++ b/README.md
@@ -2,22 +2,29 @@
 This repo implements a simplified environment for developing [Tandy
 Color Computer](https://en.wikipedia.org/wiki/TRS-80_Color_Computer)
 applications. It implements a Docker image that includes the following tools:
-* [LWTOOLS 4.20+](http://lwtools.projects.l-w.ca)
-* [ToolShed 2.2](https://sourceforge.net/p/toolshed/wiki/Home/)
-* [CMOC 0.1.80](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
-* [gcc6809](https://launchpad.net/~tormodvolden/+archive/ubuntu/m6809)
-* [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
-* [milliluk-tools](https://github.com/milliluk/milliluk-tools)
-* [nitros9/defs](https://sourceforge.net/p/nitros9/code/ci/default/tree/defs/)
-* [tlindner/cmoc\_os9](https://github.com/tlindner/cmoc_os9)
-* [Java Grinder](http://www.mikekohn.net/micro/java_grinder.php)
-* [naken](http://www.mikekohn.net/micro/naken_asm.php)
-* [coco-tools 0.5](https://github.com/jamieleecho/coco-tools)
-* [tasm6801](https://github.com/gregdionne/tasm6801)
-* [mcbasic](https://github.com/gregdionne/mcbasic)
-* [mc10-tools 0.5](https://github.com/jamieleecho/mc10-tools)
-* [ZX0](https://github.com/einar-saukas/ZX0)
-* [salvador](https://github.com/emmanuel-marty/salvador)
+* CoCo Languages and Libraries
+  * [CMOC 0.1.80](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
+  * [KAOS.Assembler](https://github.com/ChetSimpson/KAOS.Assembler)
+  * [KAOSToolkit-Prototype 1.0.0](https://github.com/ChetSimpson/KAOSToolkit-Prototype)
+  * [Java Grinder](http://www.mikekohn.net/micro/java_grinder.php)
+  * [LWTOOLS 4.20+](http://lwtools.projects.l-w.ca)
+  * [naken](http://www.mikekohn.net/micro/naken_asm.php)
+  * [nitros9/defs](https://sourceforge.net/p/nitros9/code/ci/default/tree/defs/)
+  * [tlindner/cmoc\_os9](https://github.com/tlindner/cmoc_os9)
+
+* CoCo Development Utilities
+  * [coco-tools 0.5](https://github.com/jamieleecho/coco-tools)
+  * [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
+  * [milliluk-tools](https://github.com/milliluk/milliluk-tools)
+  * [salvador](https://github.com/emmanuel-marty/salvador)
+  * [ToolShed 2.2](https://sourceforge.net/p/toolshed/wiki/Home/)
+  * [ZX0](https://github.com/einar-saukas/ZX0)
+
+* MC-10
+  * [mc10-tools 0.5](https://github.com/jamieleecho/mc10-tools)
+  * [mcbasic](https://github.com/gregdionne/mcbasic)
+  * [tasm6801](https://github.com/gregdionne/tasm6801)
+
 * Python and some useful Python packages
 
 
@@ -31,7 +38,7 @@ development environment becomes possible.
 ## Requirements
 * [macOS](https://www.apple.com/macos/high-sierra/) or
   [Linux](https://www.debian.org)
-* [Docker 17](https://www.docker.com)
+* [Docker 20](https://www.docker.com)
 
 On Mac systems you must share `/Users` with Docker. To do this:
 * From the Docker menu select `Preferences...`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ your target folder and use typical development commands such as `lwasm`,
 `lwlink`, `decb`, `os9` and `cmoc`
 
 
+### Using KAOS on coco-dev
+This version of coco-dev includes support for KAOSToolkit-Prototype as
+KAOS.Assembler. There are 4 command line tools that can be invoked using UNIX
+calling conventions, particularly using lower case letters instead of
+uppercase letters. Some examples:
+```
+./coco-dev kasm sprite1.asm
+./coco-dev kaospp -opalette.asm -ppalette.gpl -ftc1014
+./coco-dev kaostc --texture=sprite1.png --palette=palette.gpl --label-prefix=MySprite_ --pitch=128 --bpp=4 --cursor-register=Y --restore-cursor --output-file=sprite1.asm
+./coco-dev kaostp --output-file texture.raw -t texture.png -p palette.gpl
+```
+
+
 ## Building coco-dev
 ```
 # Start the Docker application if it is not already running

--- a/kaos/kaospp
+++ b/kaos/kaospp
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dotnet /usr/local/bin/KAOSPP.dll "$@"

--- a/kaos/kaostc
+++ b/kaos/kaostc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dotnet /usr/local/bin/KAOSTC.dll "$@"

--- a/kaos/kaostp
+++ b/kaos/kaostp
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dotnet /usr/local/bin/KAOSTP.dll "$@"


### PR DESCRIPTION
This version of coco-dev introduces several upgrades.

1. Includes version 1.0.0 of Chet Simpson's [KAOSToolkit-Prototype](https://github.com/ChetSimpson/KAOSToolkit-Prototype)
2. Includes Chet Simpson's [KAOS.Assembler](https://github.com/ChetSimpson/KAOS.Assembler)
3. Removes gcc-6809
4. Upgrades to Ubuntu 22.04
5. Removes older versions of Python