### PR TITLE
Remove remaining KAOS traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Color Computer](https://en.wikipedia.org/wiki/TRS-80_Color_Computer)
 applications. It implements a Docker image that includes the following tools:
 * CoCo Languages and Libraries
   * [CMOC 0.1.85](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
-  * [KAOS.Assembler](https://github.com/ChetSimpson/KAOS.Assembler)
   * [Java Grinder](http://www.mikekohn.net/micro/java_grinder.php)
   * [LWTOOLS 4.22](http://lwtools.projects.l-w.ca)
   * [naken](http://www.mikekohn.net/micro/naken_asm.php)
@@ -56,19 +55,6 @@ coco-dev/coco-dev
 This will create a Linux shell in your home directory. You can `cd` into
 your target folder and use typical development commands such as `lwasm`,
 `lwlink`, `decb`, `os9` and `cmoc`
-
-
-### Using KAOS on coco-dev
-This version of coco-dev includes support for KAOSToolkit-Prototype as
-KAOS.Assembler. There are 4 command line tools that can be invoked using UNIX
-calling conventions, particularly using lower case letters instead of
-uppercase letters. Some examples:
-```
-./coco-dev kasm sprite1.asm
-./coco-dev kaospp -opalette.asm -ppalette.gpl -ftc1014
-./coco-dev kaostc --texture=sprite1.png --palette=palette.gpl --label-prefix=MySprite_ --pitch=128 --bpp=4 --cursor-register=Y --restore-cursor --output-file=sprite1.asm
-./coco-dev kaostp --output-file texture.raw -t texture.png -p palette.gpl
-```
 
 
 ## Building coco-dev

--- a/kaos/kaospp
+++ b/kaos/kaospp
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dotnet /usr/local/bin/KAOSPP.dll "$@"

--- a/kaos/kaostc
+++ b/kaos/kaostc
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dotnet /usr/local/bin/KAOSTC.dll "$@"

--- a/kaos/kaostp
+++ b/kaos/kaostp
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-dotnet /usr/local/bin/KAOSTP.dll "$@"


### PR DESCRIPTION
The previous release should have removed these traces of KAOS. It was removed because it was not easily ported to  ARM64 builds.