### PR TITLE
Add basto6809, update CMOC and coco-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-MAINTAINER Jamie Cho version: 0.52
+LABEL org.opencontainers.image.authors="Jamie Cho"
 
 # Store stuff in a semi-reasonable spot
 WORKDIR /root
@@ -18,23 +18,30 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     dos2unix \
     ffmpeg \
     flex \
+    freeglut3-dev \
     fuse \
     g++-10 \
     git \
     imagemagick \
+    libcurl4-openssl-dev \
     libfuse-dev \
     libjpeg-dev \
     libmagickwand-dev \
+    libglu1-mesa-dev \
     mame-tools \
     markdown \
+    mesa-common-dev \
     p7zip \
     python3 \
     python3-dev \
     python3-distutils \
     python3-tk \
     software-properties-common \
+    unzip \
     vim \
-    zlib1g-dev
+    xvfb \
+    zlib1g-dev && \
+  apt-get clean
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.10 2 && \
@@ -46,7 +53,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
     pypng==0.0.20 \
     setuptools==60.9.3 \
     wand==0.5.7 \
-    coco-tools==0.6 \
+    coco-tools==0.8 \
     milliluk-tools==0.1 \
     mc10-tools==0.5
 
@@ -62,9 +69,9 @@ RUN hg clone http://hg.code.sf.net/p/toolshed/code toolshed-code && \
    make -j -C build/unix install CC=gcc)
 
 # Install CMOC
-ADD http://perso.b2b2c.ca/~sarrazip/dev/cmoc-0.1.85.tar.gz cmoc-0.1.85.tar.gz
-RUN tar -zxpvf cmoc-0.1.85.tar.gz && \
-  (cd cmoc-0.1.85 && ./configure && make && make install && make clean)
+ADD http://perso.b2b2c.ca/~sarrazip/dev/cmoc-0.1.88.tar.gz cmoc-0.1.88.tar.gz
+RUN tar -zxpvf cmoc-0.1.88.tar.gz && \
+  (cd cmoc-0.1.88 && ./configure && make && make install && make clean)
 
 # Install key OS-9 defs from nitros-9
 RUN hg clone http://hg.code.sf.net/p/nitros9/code nitros9-code && \
@@ -72,20 +79,6 @@ RUN hg clone http://hg.code.sf.net/p/nitros9/code nitros9-code && \
   hg checkout 6b7a7b233925 && \
   mkdir -p /usr/local/share/lwasm && \
   cp -R defs/* /usr/local/share/lwasm/)
-
-# Install tlindner/cmoc_os9
-RUN git clone https://github.com/jamieleecho/cmoc_os9.git && \
-  (cd cmoc_os9/lib && \
-  git checkout fix-cmoc-error && \
-  make && \
-  cd ../cgfx && \
-  make -j && \
-  cd .. && \
-  mkdir -p /usr/local/share/cmoc/lib/os9 && \
-  mkdir -p /usr/local/share/cmoc/include/os9/cgfx && \
-  cp lib/libc.a cgfx/libcgfx.a /usr/local/share/cmoc/lib/os9 && \
-  cp -R include/* /usr/local/share/cmoc/include/os9 && \
-  cp -R cgfx/include/* /usr/local/share/cmoc/include/os9)
 
 # Install java grinder
 RUN git clone https://github.com/mikeakohn/naken_asm.git && \
@@ -131,9 +124,36 @@ RUN git clone https://github.com/emmanuel-marty/salvador && \
   cp salvador /usr/local/bin && \
   make clean)
 
+# Create a user for installs
+RUN adduser mrinstaller
+USER mrinstaller
+WORKDIR /home/mrinstaller
+
+# Install qb64
+RUN git clone https://github.com/QB64-Phoenix-Edition/QB64pe.git && \
+    cd QB64pe && \
+    git checkout 56990e1a605cb639acc1ecf30619ec6f4fbcd3fa && \
+    ./setup_lnx.sh
+
+# Move qb64 to /root and Install BASIC-To-6809
+USER root
+WORKDIR /root
+RUN mv /home/mrinstaller/QB64pe /root && \
+    chown -R root:root /root/QB64pe && \
+    (Xvfb :1 -screen 0 800x600x24+32 &) && \
+    git clone https://github.com/nowhereman999/BASIC-To-6809.git && \
+    export DISPLAY=:1 && \
+    cd BASIC-To-6809 && \
+    git checkout 5cbdd5916db32d3f1a65c7c4539b677ad7e13045 && \
+    unzip BasTo6809_V1.16.zip && \
+    cd BasTo6809_V1.16 && \
+    ln -s PRINT.ASM Basic_Includes/PRINT.asm && \
+    sleep 1 && \
+    ../../QB64pe/qb64pe BasTo6809.bas -c -o basto6809
+ADD utils/basto6809todsk /usr/local/bin
+
 # Clean up
-RUN ln -s /home /Users && \
-    apt-get clean
+RUN ln -s /home /Users
 
 # For java_grinder
 ENV CLASSPATH=/root/java_grinder/build/JavaGrinder.jar \

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ This repo implements a simplified environment for developing [Tandy
 Color Computer](https://en.wikipedia.org/wiki/TRS-80_Color_Computer)
 applications. It implements a Docker image that includes the following tools:
 * CoCo Languages and Libraries
-  * [CMOC 0.1.85](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
+  * [BasTo6809 V1.16](https://github.com/nowhereman999/BASIC-To-6809)
+  * [CMOC 0.1.88](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html)
   * [Java Grinder](http://www.mikekohn.net/micro/java_grinder.php)
   * [LWTOOLS 4.22](http://lwtools.projects.l-w.ca)
   * [naken](http://www.mikekohn.net/micro/naken_asm.php)
   * [nitros9/defs](https://sourceforge.net/p/nitros9/code/ci/default/tree/defs/)
-  * [tlindner/cmoc\_os9](https://github.com/tlindner/cmoc_os9)
 
 * CoCo Development Utilities
-  * [coco-tools 0.5](https://github.com/jamieleecho/coco-tools)
+  * [coco-tools 0.8](https://github.com/jamieleecho/coco-tools)
   * [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
   * [milliluk-tools](https://github.com/milliluk/milliluk-tools)
   * [salvador](https://github.com/emmanuel-marty/salvador)

--- a/utils/basto6809todsk
+++ b/utils/basto6809todsk
@@ -1,0 +1,35 @@
+#!/bin/env bash
+
+if [[ $# -ne 1 ]] ; then
+    echo $0 PROG.BAS
+    echo Compiles PROG.BAS into a binary located on PROG.DSK
+    exit 0
+fi
+
+BAS_FILE="$1"
+ASM_FILE="${BAS_FILE%.BAS}.asm"
+BIN_FILE="${BAS_FILE%.BAS}.BIN"
+DSK_FILE="${BAS_FILE%.BAS}.DSK"
+CURRENT_DIR="`pwd`"
+
+# Create a working folder
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir')
+echo Copying compiler and source file to ${tmpdir}
+cp -R /root/BASIC-To-6809/BasTo6809_V1.16/* ${tmpdir}
+cp $1 ${tmpdir}
+cd ${tmpdir}
+
+# Do real work
+echo Compiling ${BAS_FILE} and creating ${ASM_FILE}, ${BIN_FILE} and ${DSK_FILE}
+./basto6809 "${BAS_FILE}"
+lwasm  -o "${BIN_FILE}" "$ASM_FILE"
+decb dskini "${DSK_FILE}"
+decb copy "${BIN_FILE}" "${DSK_FILE},${BIN_FILE}"
+decb attr "${DSK_FILE},${BIN_FILE}" -2 -b
+cp "${ASM_FILE}" "${CURRENT_DIR}"
+cp "${BIN_FILE}" "${CURRENT_DIR}"
+cp "${DSK_FILE}" "${CURRENT_DIR}"
+
+# Clean up
+cd "${CURRENT_DIR}"
+echo To clean up, enter: \"rm -r "${tmpdir}"\"


### PR DESCRIPTION
- Adds [basto6809](https://github.com/nowhereman999/BASIC-To-6809)
  - Includes `basto6809todsk` to make  `basto6809` easier to use
- Updates [CMOC](http://perso.b2b2c.ca/~sarrazip/dev/cmoc.html) to 0.1.88
- Updates [coco-tools](https://pypi.org/project/coco-tools/) to 0.8
- Removes [cmoc_os9](tlindner/cmoc_os9)
