### PR TITLE
Update BASIC-To-6809, coco-tools, and mc10-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ RUN python -m venv venv && \
 ENV VIRTUAL_ENV=/root/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install \
-    coco-tools==0.26 \
+    coco-tools==0.27 \
     milliluk-tools==0.1 \
-    mc10-tools==0.9 \
+    mc10-tools==0.10 \
     mypy==1.15.0 \
     numpy==2.2.6 \
     pillow==11.2.1 \
@@ -150,15 +150,15 @@ RUN curl -LO http://sarrazip.com/dev/cmoc-0.1.97.tar.gz && \
 # Build and install BASIC-To-6809
 RUN git clone https://github.com/nowhereman999/BASIC-To-6809.git && \
      cd BASIC-To-6809 && \
-     git checkout a962f3f012b347be7b9f8cc030b9997d20bc1c36 && \
+     git checkout 9c5246b5cb9d8bb7687845dcf460418e79331bdb && \
      cp Manual.pdf /usr/local/share/doc/basto6809.pdf && \
-     cd Binary_Versions/v5.11 && \
+     cd Binary_Versions && \
      if [ "$(uname -m)" = "aarch64" ]; then \
-       unzip BASIC-To-6809_v5.11_Linux_arm64.zip -d ../../../basto6809; \
+       unzip BASIC-To-6809_v5.26_Linux_arm64.zip -d ../../basto6809; \
      else \
-       unzip BASIC-To-6809_v5.11_Linux_x86_64.zip -d ../../../basto6809; \
+       unzip BASIC-To-6809_v5.26_Linux_x86_64.zip -d ../../basto6809; \
      fi && \
-     cd ../../.. && \
+     cd ../.. && \
      rm -r BASIC-To-6809 && \
      mkdir BASIC-To-6809 && \
      if [ "$(uname -m)" = "aarch64" ]; then \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Color Computer](https://en.wikipedia.org/wiki/TRS-80_Color_Computer)
 applications. It implements a Docker image that includes the following tools:
 
 * CoCo Languages and Libraries
-  * [BasTo6809 V5.11](https://github.com/nowhereman999/BASIC-To-6809)
+  * [BasTo6809 V5.26](https://github.com/nowhereman999/BASIC-To-6809)
   * [CMOC 0.1.97](http://sarrazip.com/dev/cmoc.html)
   * [Java Grinder](http://www.mikekohn.net/micro/java_grinder.php)
   * [LWTOOLS 4.24](http://lwtools.projects.l-w.ca)
@@ -13,7 +13,7 @@ applications. It implements a Docker image that includes the following tools:
   * [nitros9/defs](https://github.com/nitros9project/nitros9/tree/main/defs)
 
 * CoCo Development Utilities
-  * [coco-tools 0.26](https://pypi.org/project/coco-tools/)
+  * [coco-tools 0.27](https://pypi.org/project/coco-tools/)
   * [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
   * [milliluk-tools](https://github.com/milliluk/milliluk-tools)
   * [preprocessor](https://github.com/yggdrasilradio/preprocessor)
@@ -22,7 +22,7 @@ applications. It implements a Docker image that includes the following tools:
   * [ZX0](https://github.com/einar-saukas/ZX0)
 
 * MC-10
-  * [mc10-tools 0.9](https://pypi.org/project/mc10-tools/0.9)
+  * [mc10-tools 0.10](https://pypi.org/project/mc10-tools/0.10)
   * [mcbasic](https://github.com/gregdionne/mcbasic)
   * [tasm6801](https://github.com/gregdionne/tasm6801)
 


### PR DESCRIPTION
## Summary
- Bump BASIC-To-6809 to v5.26 (commit `9c5246b`); adjusts to the upstream repo no longer keeping per-version subdirs under `Binary_Versions/`
- Bump `coco-tools` 0.26 → 0.27
- Bump `mc10-tools` 0.9 → 0.10
- README.md updated to match

## Test plan
- [ ] `./build` succeeds on x86_64
- [ ] `./build` succeeds on arm64
- [ ] `BasTo6809`, `coco-tools`, and `mc10-tools` run inside the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)