### PR TITLE
Parallelize the image build with multi-stage stages + ccache

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           load: true
           tags: jamieleecho/coco-dev:${{ env.RELEASE_TAG }}-${{ matrix.os }}
+          build-args: |
+            MAME_JOBS=4
           cache-from: type=gha,scope=${{ matrix.os }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,21 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build.
+#
+# `foundation` holds everything shared by every later build: the apt packages,
+# the Python venv, and the two foundational toolchain pieces (lwtools and
+# toolshed) that other builds may rely on. Every remaining tool is built in its
+# own stage `FROM foundation`, so BuildKit compiles them concurrently and a
+# change to one tool no longer invalidates the others' cache. Each tool stage
+# installs into an isolated `/staging` prefix; the `final` stage assembles the
+# image with one `COPY --from=<tool> /staging/ /` per tool.
+#
+# Compile-heavy stages (mame, cmoc, java_grinder, lwtools, toolshed, zx0) use a
+# ccache BuildKit cache mount, so recompiling the same source (e.g. after a
+# cache-busting change or a `--no-cache` of an unrelated layer) is near-instant
+# locally. CI passes a higher MAME_JOBS where the runner has the RAM for it.
+
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04 AS foundation
 
 LABEL org.opencontainers.image.authors="Jamie Cho"
 
@@ -9,6 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get install -y \
     bison \
     build-essential \
+    ccache \
     curl \
     default-jdk \
     dos2unix \
@@ -60,21 +78,59 @@ RUN pip install \
     wand==0.7.0 && \
     chmod o+rx /root /root/venv
 
+# Shared ccache directory for the compile-heavy stages below. The cache lives
+# in a BuildKit cache mount (not the image); cap it so it can't grow unbounded
+# across local rebuilds.
+ENV CCACHE_DIR=/root/.ccache \
+    CCACHE_MAXSIZE=2G
+
+# --- Foundational toolchain (other build stages may depend on these) ---
+
+# Install lwtools
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  curl -O http://www.lwtools.ca/releases/lwtools/lwtools-4.24.tar.gz && \
+  tar -zxpvf lwtools-4.24.tar.gz && \
+  cd lwtools-4.24 && \
+  make -j CC="ccache gcc" && \
+  make install && \
+  cd /root && rm -rf lwtools-4.24 lwtools-4.24.tar.gz
+
+# Install Toolshed
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  git clone https://github.com/nitros9project/toolshed.git && \
+  cd toolshed && \
+  git checkout v2_5 && \
+  make -j -C build/unix CC="ccache gcc" && \
+  make -C build/unix install && \
+  cd /root && rm -rf toolshed
+
+
+# ===========================================================================
+# Parallel tool stages. Each is independent and FROM foundation, and installs
+# into /staging (mirroring the final layout) so `final` can COPY it in.
+# ===========================================================================
+
 # Install preprocessor
+FROM foundation AS preproc
 RUN git clone https://github.com/yggdrasilradio/preprocessor.git && \
   (cd preprocessor && \
    git checkout 62c4ace79eeffa48817f429363816d79abea77c3 && \
-   cp decbpp /usr/local/bin/) && \
+   mkdir -p /staging/usr/local/bin && \
+   cp decbpp /staging/usr/local/bin/) && \
   (yes | rm -r preprocessor)
 
 # Install ZX0 data compressor
-RUN git clone https://github.com/einar-saukas/ZX0 && \
+FROM foundation AS zx0
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  git clone https://github.com/einar-saukas/ZX0 && \
   cd "ZX0/src" && \
-  make -j CC=gcc CFLAGS=-O3 EXTENSION= && \
-  cp zx0 dzx0 /usr/local/bin && \
+  make -j CC="ccache gcc" CFLAGS=-O3 EXTENSION= && \
+  mkdir -p /staging/usr/local/bin && \
+  cp zx0 dzx0 /staging/usr/local/bin && \
   cd /root && rm -rf ZX0
 
 # Install salvador (fast near-optimal ZX0 compressor)
+FROM foundation AS salvador
 RUN git clone https://github.com/emmanuel-marty/salvador && \
   cd salvador && \
   git checkout 1662b625a8dcd6f3f7e3491c88840611776533f5 && \
@@ -82,91 +138,91 @@ RUN git clone https://github.com/emmanuel-marty/salvador && \
   ln -s /usr/bin/cc clang-hack/clang && \
   (PATH=./clang-hack:$PATH make -j) && \
   rm -r ./clang-hack && \
-  cp salvador /usr/local/bin && \
+  mkdir -p /staging/usr/local/bin && \
+  cp salvador /staging/usr/local/bin && \
   cd /root && rm -rf salvador
 
-# Install lwtools
-RUN curl -O http://www.lwtools.ca/releases/lwtools/lwtools-4.24.tar.gz && \
-  tar -zxpvf lwtools-4.24.tar.gz && \
-  cd lwtools-4.24 && \
-  make -j CC=gcc && \
-  make install && \
-  cd /root && rm -rf lwtools-4.24 lwtools-4.24.tar.gz
-
-# Install Toolshed
-RUN git clone https://github.com/nitros9project/toolshed.git && \
-  cd toolshed && \
-  git checkout v2_5 && \
-  make -j -C build/unix CC=gcc && \
-  make -C build/unix install && \
-  cd /root && rm -rf toolshed
-
 # Install key OS-9 defs from nitros-9
+FROM foundation AS nitros9
 RUN git clone https://github.com/nitros9project/nitros9.git && \
   cd nitros9 && \
   git checkout 27c67d5c445db631abfd5b45d49870364d9eacb6 && \
-  mkdir -p /usr/local/share/lwasm && \
-  cp -R defs/* /usr/local/share/lwasm/ && \
+  mkdir -p /staging/usr/local/share/lwasm && \
+  cp -R defs/* /staging/usr/local/share/lwasm/ && \
   cd /root && rm -rf nitros9
 
-# Install java grinder
-RUN git clone https://github.com/mikeakohn/naken_asm.git && \
+# Install java grinder (and naken_asm, which builds it and runs the tests)
+FROM foundation AS jgrinder
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  git clone https://github.com/mikeakohn/naken_asm.git && \
   git clone https://github.com/mikeakohn/java_grinder && \
   cd naken_asm && \
   git checkout b6e83f1976a5fa0b1a371bd4d6db935a386b95ef && \
   ./configure && \
-  make -j && \
+  make CC="ccache gcc" && \
   make install && \
   cd ../java_grinder && \
   git checkout 4dca222bae458766c320f045c015754aa6c17376 && \
-  make -j && \
+  make -j CC="ccache gcc" CXX="ccache g++" && \
   make java && \
   (cd samples/trs80_coco && make -j grind) && \
-  cp java_grinder /usr/local/bin/ && \
-  mkdir -p /usr/local/share/java_grinder && \
-  cp build/JavaGrinder.jar /usr/local/share/java_grinder/ && \
+  mkdir -p /staging/usr/local/bin /staging/usr/local/share/java_grinder && \
+  cp /usr/local/bin/naken_asm /usr/local/bin/naken_util /staging/usr/local/bin/ && \
+  cp -R /usr/local/share/naken_asm /staging/usr/local/share/ && \
+  cp java_grinder /staging/usr/local/bin/ && \
+  cp build/JavaGrinder.jar /staging/usr/local/share/java_grinder/ && \
   cd /root && rm -rf naken_asm java_grinder
 
-# Install tasm and mcbasic
+# Install tasm6801
+FROM foundation AS tasm
 RUN git clone https://github.com/gregdionne/tasm6801.git && \
-  git clone https://github.com/gregdionne/mcbasic.git && \
   cd tasm6801 && \
   git checkout 0820625bf8e78053ced348a3d747191d54e5e24f && \
   cd src && \
   make -j && \
-  cp ../tasm6801 /usr/local/bin && \
-  cd ../../mcbasic && \
+  mkdir -p /staging/usr/local/bin && \
+  cp ../tasm6801 /staging/usr/local/bin && \
+  cd /root && rm -rf tasm6801
+
+# Install mcbasic
+FROM foundation AS mcbasic
+RUN git clone https://github.com/gregdionne/mcbasic.git && \
+  cd mcbasic && \
   git checkout 1030ec4413df400e07709a9aabffcaaf4772eb82 && \
   make -j && \
-  cp mcbasic /usr/local/bin && \
-  cd /root && rm -rf tasm6801 mcbasic
+  mkdir -p /staging/usr/local/bin && \
+  cp mcbasic /staging/usr/local/bin && \
+  cd /root && rm -rf mcbasic
 
 # Install CMOC
-RUN curl -LO http://sarrazip.com/dev/cmoc-0.1.98.tar.gz && \
+FROM foundation AS cmoc
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  curl -LO http://sarrazip.com/dev/cmoc-0.1.98.tar.gz && \
   tar -zxpvf cmoc-0.1.98.tar.gz && \
   cd cmoc-0.1.98 && \
-  ./configure && \
+  ./configure CC="ccache gcc" CXX="ccache g++" && \
   make && \
-  make install && \
+  make install DESTDIR=/staging && \
   cd /root && rm -rf cmoc-0.1.98 cmoc-0.1.98.tar.gz
 
 # Build and install BASIC-To-6809
+FROM foundation AS basto
 RUN git clone https://github.com/nowhereman999/BASIC-To-6809.git && \
      cd BASIC-To-6809 && \
      git checkout 0e60e91fae063324fb9608f0117f6e9ac0582125 && \
-     cp Manual.pdf /usr/local/share/doc/basto6809.pdf && \
+     mkdir -p /staging/usr/local/share/doc && \
+     cp Manual.pdf /staging/usr/local/share/doc/basto6809.pdf && \
      cd Binary_Versions && \
      if [ "$(uname -m)" = "aarch64" ]; then \
        unzip BASIC-To-6809_v5.28_Linux_arm64.zip -d /tmp/basto6809 && \
-       mv /tmp/basto6809/BASIC-To-6809_Linux_arm64 /usr/local/share/basto6809; \
+       mv /tmp/basto6809/BASIC-To-6809_Linux_arm64 /staging/usr/local/share/basto6809; \
      else \
        unzip BASIC-To-6809_v5.28_Linux_x86_64.zip -d /tmp/basto6809 && \
-       mv /tmp/basto6809/BASIC-To-6809_Linux_x86_64 /usr/local/share/basto6809; \
+       mv /tmp/basto6809/BASIC-To-6809_Linux_x86_64 /staging/usr/local/share/basto6809; \
      fi && \
-     mv "/usr/local/share/basto6809/BasTo6809.2.Compile copy" "/usr/local/share/basto6809/BasTo6809.2.Compile" && \
-     chmod -R o+rx /usr/local/share/basto6809 && \
+     mv "/staging/usr/local/share/basto6809/BasTo6809.2.Compile copy" "/staging/usr/local/share/basto6809/BasTo6809.2.Compile" && \
+     chmod -R o+rx /staging/usr/local/share/basto6809 && \
      cd /root && rm -rf BASIC-To-6809 /tmp/basto6809
-COPY utils/basto6809todsk /usr/local/bin
 
 # Build and install a headless, CoCo 3-only MAME.
 #
@@ -179,10 +235,13 @@ COPY utils/basto6809todsk /usr/local/bin
 # MAME's core has several very large translation units (luaengine, emumem) that
 # each need ~2GB of RAM in the compiler, so the job count is kept low to avoid
 # the OOM killer (MAME_JOBS=2 needs ~4GB). Lower it to 1 on a RAM-starved host,
-# or raise it (e.g. --build-arg MAME_JOBS=4) when there is RAM to spare.
+# or raise it (e.g. --build-arg MAME_JOBS=4) when there is RAM to spare; CI
+# passes MAME_JOBS=4 because the hosted runners have 16GB.
+FROM foundation AS mame
 ARG MAME_VERSION=0287
 ARG MAME_JOBS=2
-RUN git clone --depth 1 --branch mame$MAME_VERSION \
+RUN --mount=type=cache,target=/root/.ccache,sharing=shared \
+  git clone --depth 1 --branch mame$MAME_VERSION \
       https://github.com/mamedev/mame.git && \
   cd mame && \
   make -j"$MAME_JOBS" \
@@ -192,13 +251,35 @@ RUN git clone --depth 1 --branch mame$MAME_VERSION \
     TOOLS=0 \
     USE_QTDEBUG=0 \
     NO_USE_PORTAUDIO=1 \
-    PYTHON_EXECUTABLE=python3 && \
-  (install -m 0755 coco /usr/local/bin/mame 2>/dev/null || \
-   install -m 0755 mamecoco /usr/local/bin/mame) && \
-  mkdir -p /usr/local/share/mame && \
-  cp -R plugins language /usr/local/share/mame/ && \
-  chmod -R o+rx /usr/local/share/mame && \
+    PYTHON_EXECUTABLE=python3 \
+    OVERRIDE_CC="ccache gcc" \
+    OVERRIDE_CXX="ccache g++" && \
+  mkdir -p /staging/usr/local/bin && \
+  (install -m 0755 coco /staging/usr/local/bin/mame 2>/dev/null || \
+   install -m 0755 mamecoco /staging/usr/local/bin/mame) && \
+  mkdir -p /staging/usr/local/share/mame && \
+  cp -R plugins language /staging/usr/local/share/mame/ && \
+  chmod -R o+rx /staging/usr/local/share/mame && \
   cd /root && rm -rf mame
+
+
+# ===========================================================================
+# Final image: foundation plus every tool's staged artifacts.
+# ===========================================================================
+FROM foundation AS final
+
+COPY --from=preproc  /staging/ /
+COPY --from=zx0      /staging/ /
+COPY --from=salvador /staging/ /
+COPY --from=nitros9  /staging/ /
+COPY --from=jgrinder /staging/ /
+COPY --from=tasm     /staging/ /
+COPY --from=mcbasic  /staging/ /
+COPY --from=cmoc     /staging/ /
+COPY --from=basto    /staging/ /
+COPY --from=mame     /staging/ /
+
+COPY utils/basto6809todsk /usr/local/bin
 
 # Link so things work nicely with macOS
 RUN ln -s /home /Users

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ help:
 	@echo "Override the tag with TAG=...  (e.g. make test TAG=jamieleecho/coco-dev:0.79)"
 
 build:
-	docker compose -f docker-compose.build.yml build
+	docker compose -f docker-compose.build.yml build \
+		$(if $(MAME_JOBS),--build-arg MAME_JOBS=$(MAME_JOBS))
 
 test:
 	docker run --rm -v "$(CURDIR)/tests:/sources:ro" $(TAG) bash -euc '\

--- a/README.md
+++ b/README.md
@@ -111,16 +111,22 @@ Run `make help` to see the available targets. After building, `make test`
 runs a quick smoke test that exercises CMOC, BasTo6809, mcbasic, Java
 Grinder, and the CoCo 3 MAME build against the built image.
 
+The image is a multi-stage build: a shared `foundation` stage (apt packages,
+the Python venv, lwtools and toolshed) followed by one stage per tool, which
+BuildKit compiles in parallel. Compile-heavy stages use a `ccache` cache mount,
+so rebuilding unchanged sources locally is fast.
+
 Building MAME from source is the slow part of the image build. A few of MAME's
 core source files need ~2 GB of RAM each in the compiler, so the job count is
 deliberately conservative: it defaults to `MAME_JOBS=2` (~4 GB peak). If your
 Docker host has plenty of RAM you can speed the build up by raising it, e.g.:
 
 ```bash
-docker compose -f docker-compose.build.yml build \
-  --build-arg MAME_JOBS=4
+make build MAME_JOBS=4
 ```
 
-If the build is killed for memory, either lower it to `--build-arg MAME_JOBS=1`
-or increase the memory allotted to Docker (Docker Desktop → Settings →
-Resources).
+Because the tool stages build concurrently, MAME's compile now overlaps with
+the other tools', so size `MAME_JOBS` against the RAM you have free *during*
+the build, not in isolation. If the build is killed for memory, lower it (down
+to `MAME_JOBS=1`) or increase the memory allotted to Docker (Docker Desktop →
+Settings → Resources).


### PR DESCRIPTION
## Problem

Builds had become horrendously slow: the Dockerfile compiled ~10 tools from source in a single linear chain, so each tool waited on the one before it, and MAME (the biggest by far) blocked everything after it.

## Changes

- **Multi-stage Dockerfile.** A shared `foundation` stage (apt + Python venv + the foundational **lwtools** and **toolshed**), then **one independent stage per remaining tool** (`FROM foundation`). BuildKit compiles these concurrently, and a change to one no longer invalidates the others' cache. Each stage installs into an isolated `/staging` prefix; the `final` stage assembles via `COPY --from=<tool> /staging/ /` (which also drops source/build trees from the runtime image).
- **ccache.** BuildKit cache mounts (capped at 2 GB) on the compile-heavy stages (mame, cmoc, java_grinder, lwtools, toolshed, zx0). Recompiling unchanged sources is near-instant on subsequent **local** builds.
- **`MAME_JOBS=4` in CI.** The hosted `ubuntu-24.04`/`-arm` runners have 4 vCPU / 16 GB, so 4 jobs roughly halves MAME's compile. Dockerfile default stays `2` for low-RAM local hosts.
- **`make build MAME_JOBS=N`.** Forwards the override locally (defaults to 2).
- **README** updated to document the multi-stage/parallel + ccache design and the new invocation.

## Impact

The ~9 non-MAME tools now build in parallel alongside MAME instead of serially before it, so wall-clock is gated mostly by MAME alone. Image size is unchanged: 5.41 GB (+~10 MB, just the added `ccache` package).

## Verification

- `docker build --check`: clean
- Full local build: exit 0, parallel stages confirmed running concurrently
- `make test`: all 5 smoke tests pass (java_grinder, basto6809todsk, mcbasic, cmoc --os9, mame coco3 headless)

## ⚠️ Watch item

Tool stages now compile **concurrently**, so MAME's build (at `MAME_JOBS=4`, ~8 GB) overlaps with cmoc/java_grinder rather than running alone. Watch the first CI run on each arch; if the OOM killer appears, drop CI to `MAME_JOBS=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)