### PR TITLE
Add doxygen + graphviz for C source documentation (HTML)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     curl \
     default-jdk \
     dos2unix \
+    doxygen \
     ffmpeg \
     flex \
     freeglut3-dev \
     fuse \
     git \
+    graphviz \
     imagemagick \
     libcurl4-openssl-dev \
     libfontconfig1-dev \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ applications. It implements a Docker image that includes the following tools:
 
 * CoCo Development Utilities
   * [coco-tools 0.27](https://pypi.org/project/coco-tools/)
+  * [Doxygen](https://www.doxygen.nl) (with [Graphviz](https://graphviz.org) for diagrams; HTML output)
   * [MAME 0.287](https://www.mamedev.org) (headless, CoCo 3-only build)
   * [MAME Tools](https://packages.ubuntu.com/xenial/utils/mame-tools)
   * [milliluk-tools](https://github.com/milliluk/milliluk-tools)


### PR DESCRIPTION
## What

Adds **doxygen** (with **graphviz** for call/collaboration diagrams) so the container can scan C headers and generate **HTML** documentation — e.g. for publishing to GitHub Pages.

## Why this way

- They're plain runtime apt packages (no compile), so they go in the `foundation` stage alongside the other apt deps — one-line additions, no new build stage.
- **HTML only.** Doxygen has no native PDF writer; PDF would require a LaTeX/texlive toolchain (~+360 MB). Left out for now — easy to add later if needed.

## Size impact

doxygen + graphviz add ~282 MB on disk (graphviz is only ~40 MB of that; doxygen's own deps are the bulk). Image goes from ~5.41 GB → ~5.7 GB.

## Verification

Built the `foundation` target and ran the tools in-image:
- `doxygen --version` → `1.9.8`
- `dot -V` → `graphviz version 2.43.0`
- `docker build --check` → clean

## Usage

Generate HTML docs from C headers inside the container, e.g.:

```bash
doxygen -g            # create a Doxyfile, then set INPUT/RECURSIVE/HAVE_DOT=YES
doxygen Doxyfile      # writes html/ (publishable to GitHub Pages)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)